### PR TITLE
return 'transparent' for rgba(0, 0, 0, 0) (white space insensitive)

### DIFF
--- a/rgbHex.js
+++ b/rgbHex.js
@@ -45,6 +45,10 @@ window.rgbHex = (function() {
         }
     }
 
+    function removeWhitespace(arg) {
+        return arg.replace(/\s/g, '');
+    }
+
     return function(arg) {        
         if(!arg) { return null; }
 
@@ -56,6 +60,9 @@ window.rgbHex = (function() {
         
         if (arg === 'transparent') {
             return arg;
+        }
+        if (removeWhitespace(arg) === 'rgba(0,0,0,0)') {
+            return 'transparent';
         }
         if (rgbRegex.test(arg)) {
             return processRgb(arg.match(rgbRegex)[1]);

--- a/tests.js
+++ b/tests.js
@@ -4,6 +4,8 @@ module('rgbHex');
 
 test('rgb to hex - valid', function() {
   equal( window.rgbHex( 'transparent' ), 'transparent' );
+  equal( window.rgbHex( 'rgba(0, 0, 0, 0)' ), 'transparent' );
+  equal( window.rgbHex( 'rgba(0,0,0,0)' ), 'transparent' );
   equal( window.rgbHex( 'rgb(255,255,255)' ), '#FFFFFF' );
   equal( window.rgbHex( 'rgb(255, 255, 255) ' ), '#FFFFFF' );
   equal( window.rgbHex( 'rgb(255, 255, 255, 0.4) ' ), '#FFFFFF' );


### PR DESCRIPTION
Couldn't select the transparent color using wPaint and tracked it all the way down here.
It seemed that jQuery (or Chrome) are converting background-color:transparent to rgba(0,0,0,0) **when the element is added to the DOM tree** (took me some time to figure this out).

See the following code that I (a similar thing occurs on wColorPicker):

``` javascript
el = $("<div style='background-color:transparent'></div>");
el.css('backgroundColor');
//"transparent"

$('body').append(el);
el.css('backgroundColor');
//"rgba(0, 0, 0, 0)"
```

Tested it in wPaint  through building wColorPicker.
Didn't want to include the distributable files in the pull request, so the minimized files (and version number) remain the same.

Thanks for all your excellent work, learned a lot reading through the code!
